### PR TITLE
Simplify some methods

### DIFF
--- a/mere_test.go
+++ b/mere_test.go
@@ -86,7 +86,7 @@ func TestNewSpecErrors(t *testing.T) {
 			assert := assert.New(t)
 			var buf bytes.Buffer
 			_, err := mere.NewSpec(tc.filename, &buf)
-			assert.EqualError(err, tc.errMsg)
+			assert.Contains(err.Error(), tc.errMsg)
 		})
 	}
 }


### PR DESCRIPTION
- split buildSteps to an initial setup method and the main execution
  method
- remove a conditional in validateSchema and just return the last result
  of json.Unmarshal
- collect errors and return all of them together in renderAll
- adjust tests to match